### PR TITLE
Added destroy method to cancel an scheduled update when the device is…

### DIFF
--- a/netatmo.coffee
+++ b/netatmo.coffee
@@ -160,16 +160,21 @@ module.exports = (env) ->
       @device_id = @config.device_id
       @interval = 1000 * @config.interval
 
-      
+
       updateValue = =>
         if @config.interval > 0
           @getDeviceData().finally( =>
             env.logger.debug "Scheduling next update for #{@name} with interval #{@interval}ms"
-            setTimeout(updateValue, @interval) 
+            @timeoutId = setTimeout(updateValue, @interval)
           )
       
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout(@timeoutId) if @timeoutId?
+      @_currentRequest.cancel() if @_currentRequest?
+      super()
 
     getDeviceData: () ->
      options =
@@ -256,11 +261,16 @@ module.exports = (env) ->
         if @config.interval > 0
           @getDeviceData().finally( =>
             env.logger.debug "Scheduling next update for #{@name} with interval #{@interval}ms"
-            setTimeout(updateValue, @interval) 
+            @timeoutId = setTimeout(updateValue, @interval)
           )
       
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout(@timeoutId) if @timeoutId?
+      @_currentRequest.cancel() if @_currentRequest?
+      super()
 
     getDeviceData: () ->
      options =
@@ -340,11 +350,16 @@ module.exports = (env) ->
         if @config.interval > 0
           @getDeviceData().finally( =>
             env.logger.debug "Scheduling next update for #{@name} with interval #{@interval}ms"
-            setTimeout(updateValue, @interval) 
+            @timeoutId = setTimeout(updateValue, @interval)
           )
       
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout(@timeoutId) if @timeoutId?
+      @_currentRequest.cancel() if @_currentRequest?
+      super()
 
     getDeviceData: () ->
      options =
@@ -434,11 +449,16 @@ module.exports = (env) ->
         if @config.interval > 0
           @getDeviceData().finally( =>
             env.logger.debug "Scheduling next update for #{@name} with interval #{@interval}ms"
-            setTimeout(updateValue, @interval) 
+            @timeoutId = setTimeout(updateValue, @interval)
           )
       
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout(@timeoutId) if @timeoutId?
+      @_currentRequest.cancel() if @_currentRequest?
+      super()
 
     getDeviceData: () ->
      options =
@@ -514,11 +534,16 @@ module.exports = (env) ->
         if @config.interval > 0
           @getDeviceData().finally( =>
             env.logger.debug "Scheduling next update for #{@name} with interval #{@interval}ms"
-            setTimeout(updateValue, @interval) 
+            @timeoutId = setTimeout(updateValue, @interval)
           )
       
       super()
       updateValue()
+
+    destroy: () ->
+      clearTimeout(@timeoutId) if @timeoutId?
+      @_currentRequest.cancel() if @_currentRequest?
+      super()
 
     getDeviceData: () ->
      options =


### PR DESCRIPTION
… removed or updated with pimatic 0.9. This is another requirement for pimatic 0.9 (code will also run with pimatic 0.8)

Apart from this I have noticed there is a bit of code doubling among the various device implementations. You should conisder implementing a common base class which contains the updateService and other things. This should be fairly easy as all device classes currently inherit from env.devices.Device. If this will be different in the future consider implementing an aggregate.
